### PR TITLE
Potential fix for code scanning alert no. 4: Log entries created from user input

### DIFF
--- a/internal/application/handlers/web/auth.go
+++ b/internal/application/handlers/web/auth.go
@@ -62,6 +62,8 @@ func (h *AuthHandler) showLoginPage(c echo.Context) error {
 // handleLogin processes the login request
 func (h *AuthHandler) handleLogin(c echo.Context) error {
 	email := c.FormValue("email")
+	email = strings.ReplaceAll(email, "\n", "")
+	email = strings.ReplaceAll(email, "\r", "")
 	password := c.FormValue("password")
 
 	h.Logger.Debug("login attempt",

--- a/internal/domain/user/service.go
+++ b/internal/domain/user/service.go
@@ -221,6 +221,8 @@ func (s *ServiceImpl) IsTokenBlacklisted(ctx context.Context, token string) (boo
 
 // Authenticate matches the domain.UserService interface
 func (s *ServiceImpl) Authenticate(ctx context.Context, email, password string) (*User, error) {
+	email = strings.ReplaceAll(email, "\n", "")
+	email = strings.ReplaceAll(email, "\r", "")
 	s.logger.Debug("attempting authenticate",
 		logging.StringField("email", email),
 		logging.BoolField("has_password", password != ""),

--- a/internal/infrastructure/logging/factory.go
+++ b/internal/infrastructure/logging/factory.go
@@ -213,7 +213,13 @@ func convertToZapFields(fields []any) []zap.Field {
 	for i, f := range fields {
 		switch v := f.(type) {
 		case LogField:
-			zapFields[i] = zap.Any(v.Key, v.Value)
+			if strValue, ok := v.Value.(string); ok {
+				strValue = strings.ReplaceAll(strValue, "\n", "")
+				strValue = strings.ReplaceAll(strValue, "\r", "")
+				zapFields[i] = zap.Any(v.Key, strValue)
+			} else {
+				zapFields[i] = zap.Any(v.Key, v.Value)
+			}
 		case error:
 			zapFields[i] = zap.Error(v)
 		default:


### PR DESCRIPTION
Potential fix for [https://github.com/goformx/goforms/security/code-scanning/4](https://github.com/goformx/goforms/security/code-scanning/4)

To fix the issue, user input should be sanitized before being passed to the logging system. Specifically, any user-provided values (e.g., `email`) should be stripped of potentially dangerous characters such as newlines (`\n`, `\r`) or encoded to prevent log forgery. This can be achieved using `strings.ReplaceAll` for plain text logs or `html.EscapeString` for logs displayed in HTML.

The sanitization should be applied at the point where user input is first processed (e.g., in `handleLogin` in `auth.go`) or before it is passed to the logger (e.g., in `convertToZapFields` in `factory.go`). This ensures that all log entries are safe regardless of where the user input originates.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
